### PR TITLE
Fix for .yari installation paths which contain spaces.

### DIFF
--- a/bin/yari.cmd
+++ b/bin/yari.cmd
@@ -1,7 +1,7 @@
 @echo off
 if "%*" == "" goto :usage
 
-@powershell -ExecutionPolicy RemoteSigned "%~dp0..\rubyinstaller.ps1" %*
+@powershell -ExecutionPolicy RemoteSigned "& '%~dp0..\rubyinstaller.ps1'" %*
 
 if not exist "%~dp0..\yari.tmp.cmd" (
     echo something didn't work quite right...


### PR DESCRIPTION
Fixed this problem:

D:\p4\www\expweb\trunk>yari 1.9.2
The term 'C:\Documents' is not recognized as the name of a cmdlet, function, sc
ript file, or operable program. Check the spelling of the name, or if a path wa
s included, verify that the path is correct and try again.

Did no one on the powershell team consider that MS encourages people to keep their files in a directory with spaces in the path?

Reference: http://arcware.net/running-a-powershell-script-with-a-space-in-the-path/
