### PR TITLE
Add support for Ruby 2.1.6

### DIFF
--- a/bin/yari.cmd
+++ b/bin/yari.cmd
@@ -17,7 +17,7 @@ echo Sets up a ruby environment for you
 echo. 
 echo rubyenv [version] [-InstallMachine]
 echo.
-echo   version          1.8.7, 1.9.3, 2.0.0, 2.2.2
+echo   version          1.8.7, 1.9.3, 2.0.0, 2,1,6, 2.2.2
 echo   -InstallMachine  permanently sets your machines PATH otherwise it only
 echo                    sets it for the current session
 echo. 

--- a/rubyinstaller.ps1
+++ b/rubyinstaller.ps1
@@ -30,6 +30,11 @@ $registry = @{
         "gem_path" = "lib\ruby\gems\2.0.0\bin";
         "devkit" = "devkit-4.7.2"
     };
+    "2.1.6" = @{
+        "url" = "http://dl.bintray.com/oneclick/rubyinstaller/ruby-2.1.6-i386-mingw32.7z";
+        "gem_path" = "lib\ruby\gems\2.1.0\bin";
+        "devkit" = "devkit-4.7.2"
+    };
     "2.2.2" = @{
         "url" = "http://dl.bintray.com/oneclick/rubyinstaller/ruby-2.2.2-i386-mingw32.7z";
         "gem_path" = "lib\ruby\gems\2.2.0\bin";


### PR DESCRIPTION
One more change from me. I discovered that not all gems had full support for Ruby 2.2. I therefore needed to use Ruby 2.1 in my work instead. Ergo, added support for this version.