### PR TITLE
Fixed Gem path for Ruby 2.3.1

### DIFF
--- a/rubyinstaller.ps1
+++ b/rubyinstaller.ps1
@@ -47,7 +47,7 @@ $registry = @{
     };
     "2.3.1" = @{
         "url" = "http://dl.bintray.com/oneclick/rubyinstaller/ruby-2.3.1-i386-mingw32.7z"
-        "gem_path" = "lib\ruby\gems\2.2.0\bin"
+        "gem_path" = "lib\ruby\gems\2.3.0\bin"
         "devkit" = "devkit-4.7.2"
     }
     "devkit-4.5.2" = @{


### PR DESCRIPTION
Updated Gem path for Ruby 2.3.1. Should point to 2.3.0, not 2.2.0.